### PR TITLE
Support modules-codemod being in a sibling directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "debug": "^3.0.0",
     "ember-modules-codemod": "^0.2.9",
+    "execa": "^0.8.0",
     "git-diff-apply": "^0.6.1",
     "rfc6902-ordered": "^2.0.0",
     "semver": "^5.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const fork = require('child_process').fork;
 const getPackageVersion = require('./get-package-version');
 const getProjectVersion = require('./get-project-version');
 const getTagVersion = require('./get-tag-version');
@@ -11,8 +10,8 @@ const autoMergePackageJson = require('./auto-merge-package-json');
 const gitDiffApply = require('git-diff-apply');
 const semver = require('semver');
 const run = require('./run');
+const execa = require('execa');
 
-const modulesCodemodPath = path.join(__dirname, '../node_modules/ember-modules-codemod/bin/ember-modules-codemod');
 const modulesCodemodVersion = '2.16.0-beta.1';
 
 module.exports = function emberCliUpdate(options) {
@@ -72,11 +71,11 @@ module.exports = function emberCliUpdate(options) {
 
     let shouldRunModulesCodemod = semver.lt(startVersion, modulesCodemodVersion) && semver.gte(endVersion, modulesCodemodVersion);
     if (shouldRunModulesCodemod) {
-      return new Promise(resolve => {
-        let cp = fork(modulesCodemodPath);
-
-        cp.on('exit', resolve);
-      }).then(() => {
+      let opts = {
+        localDir: path.join(__dirname, '..'),
+        stdio: 'inherit'
+      };
+      return execa('ember-modules-codemod', opts).then(() => {
         run('git add -A');
       });
     }


### PR DESCRIPTION
For some reason when I install ember-cli-update via `yarn global add`, it hoists ember-modules-codemod to the node_modules root, so it's a sibling to the ember-cli-update directory instead of contained in ember-cli-update's node_modules directory.

Although I didn't do this myself, if somebody manually installed the same version of ember-modules-codemod, I believe this same directory structure would end up being the case.

This commit allowxs ember-cli-update to tolerate either directory structure.

## Testing note

I was unable to figure out a good way to test this new functionality. Existing tests verify that it didn't regress the child directory structure, but the sibling directory structure is un-unit tested (but of course I verified it manually). I'd definitely be open to suggestions for how to unit test it. Or maybe we should just open a PR in `ember-modules-codemod` to add an `index.js` with an API so we can just `require` it rather than guessing at the filesystem layout...