### PR TITLE
Fix incorrect tag version for glimmer projects

### DIFF
--- a/src/get-tag-version.js
+++ b/src/get-tag-version.js
@@ -26,12 +26,11 @@ module.exports = function getTagVersion(to, versions, projectType) {
     let pkg;
 
     switch (projectType) {
-      case 'app':
-      case 'addon':
-        pkg = 'ember-cli';
-        break;
       case 'glimmer':
         pkg = '@glimmer/blueprint';
+        break;
+      default:
+        pkg = 'ember-cli';
         break;
     }
 

--- a/src/get-tag-version.js
+++ b/src/get-tag-version.js
@@ -8,7 +8,7 @@ const distTags = [
   'beta'
 ];
 
-module.exports = function getTagVersion(to, versions) {
+module.exports = function getTagVersion(to, versions, projectType) {
   let distTag;
   let version;
   if (distTags.indexOf(to) > -1) {
@@ -23,8 +23,20 @@ module.exports = function getTagVersion(to, versions) {
       version = semver.maxSatisfying(versions, version);
     }
   } else {
+    let pkg;
+
+    switch (projectType) {
+      case 'app':
+      case 'addon':
+        pkg = 'ember-cli';
+        break;
+      case 'glimmer':
+        pkg = '@glimmer/blueprint';
+        break;
+    }
+
     version = JSON.parse(
-      run(`npm info ember-cli@${distTag} version --json`)
+      run(`npm info ${pkg}@${distTag} version --json`)
     );
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ module.exports = function emberCliUpdate(options) {
     }
   }
 
-  let endVersion = getTagVersion(to, versions);
+  let endVersion = getTagVersion(to, versions, projectType);
 
   let remoteUrl = getRemoteUrl(projectType);
 


### PR DESCRIPTION
Allow glimmer project to update to latest @glimmer/blueprint without having to specify --to option