### PR TITLE
Adding troubleshooting tips to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,12 @@ If you are getting an error or unexpected results, running the command with the 
 * Windows (command):&nbsp;&nbsp;&nbsp;`set DEBUG=ember-cli-update,git-diff-apply && ember update`
 
 will give you more detailed logging.
+
+#### Troubleshooting tips
+
+- .gitconfig
+    The color attribute should be auto.
+    ```sh
+    [color]
+      ui = auto
+    ```


### PR DESCRIPTION
In the `.gitconfig` Having color ui set to `alway` caused an error `unrecognized input`

```sh
[color]
  ui = always
```

Change that to: 
```sh
[color]
  ui = auto
```

https://stackoverflow.com/questions/37347350/all-git-patches-i-create-throw-fatal-unrecognized-input