### PR TITLE
Adding troubleshooting tips to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,14 @@ If you are getting an error or unexpected results, running the command with the 
 * Windows (command):&nbsp;&nbsp;&nbsp;`set DEBUG=ember-cli-update,git-diff-apply && ember update`
 
 will give you more detailed logging.
+
+#### Troubleshooting tips
+Running into the following error `{ Error: Command failed: git apply /var/folders/59/.../T/tmp-.../file.patch
+error: unrecognized input` you may need to update your gitconfig color option.
+
+- .gitconfig
+    The color attribute should be auto.
+    ```sh
+    [color]
+      ui = auto
+    ```


### PR DESCRIPTION
`Error: Command failed: git apply /var/folders/59/.../T/tmp-.../file.patch error: unrecognized input `

In the .gitconfig Having color ui set to alway caused the above error.

[color]
  ui = always
Change that to:

[color]
  ui = auto

https://stackoverflow.com/questions/37347350/all-git-patches-i-create-throw-fatal-unrecognized-input

Sorry, @kellyselden I thought I had pushed an update to #236 a while ago.